### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,29 +6,29 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ReceiveEvent  KEYWORD1
-OneWireSlave  KEYWORD1
-Pin KEYWORD1
-OWSlave KEYWORD1
+ReceiveEvent	KEYWORD1
+OneWireSlave	KEYWORD1
+Pin	KEYWORD1
+OWSlave	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-end KEYWORD2
-setReceiveCallback  KEYWORD2
-setReceiveBitCallback KEYWORD2
-write KEYWORD2
-writeBit  KEYWORD2
-stopWrite KEYWORD2
-alarmed KEYWORD2
-crc8  KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+setReceiveCallback	KEYWORD2
+setReceiveBitCallback	KEYWORD2
+write	KEYWORD2
+writeBit	KEYWORD2
+stopWrite	KEYWORD2
+alarmed	KEYWORD2
+crc8	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-RE_Reset  LITERAL1
-RE_Byte LITERAL1
-RE_Error  LITERAL1
+RE_Reset	LITERAL1
+RE_Byte	LITERAL1
+RE_Error	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords